### PR TITLE
Ability to skip vendor and specific git remote name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,14 @@
 dist: trusty
 sudo: false
 
+git:
+  depth: 1
+
 language: go
+
 go:
-  - 1.8.x
-  - 1.9.x
+  - 1.10.x
+  - 1.11.x
   - tip
 
 go_import_path: bramp.net/goredirects
@@ -12,6 +16,8 @@ go_import_path: bramp.net/goredirects
 before_install:
   - go get github.com/mattn/goveralls
   - go get golang.org/x/tools/cmd/cover
+  - go get ./...
 
 script:
+  - go test -v ./...
   - $HOME/gopath/bin/goveralls -service=travis-ci

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ $ go install bramp.net/goredirects
 
 $ goredirects
 Usage: goredirects <domain> <output dir>
+  -git-remote string
+        Git remote name (default "origin")
+  -include-vendor
+        Include vendor directory
 
 $ goredirects bramp.net outputdir
 # Looking under $GOROOT/src/bramp.net for all packages


### PR DESCRIPTION
Introducing -include-vendor flag to generate vanity URLs for vendored
packages, off by default. Adding ability to override the default
"origin" remote name used to determine the URLs.

Fixes #4 and #5 

Usage:
```
goredirects -include-vendor bramp.net outputdir
goredirects -git-remote=upstream bramp.net outputdir
goredirects -git-remote=upstream -include-vendor bramp.net outputdir
```

We maybe should abstract out the package and use a separate `cmd` using https://github.com/spf13/cobra for more user friendly CLI flag parsing. This will allow to embed this package in other logic as well.